### PR TITLE
Deploy docs to GitHub Pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
The _actual_ workflow to deploy docs to GitHub Pages. All the PRs prior to this deal with docs generation and rsync-ing them over to this repo. 